### PR TITLE
Fixes to `!lotrfatigue` command

### DIFF
--- a/collection/LOTR 5E/lotrfatigue.alias
+++ b/collection/LOTR 5E/lotrfatigue.alias
@@ -48,10 +48,6 @@ if args.get('mount'):
 if args.get('b'):
     bonuses.extend(args.get('b'))
 
-# Check for autumn/winter override
-if 'autumn' in args or 'winter' in args:
-    adv = -1
-
 # Process events
 final_dc = dc
 

--- a/collection/LOTR 5E/lotrfatigue.alias
+++ b/collection/LOTR 5E/lotrfatigue.alias
@@ -2,7 +2,6 @@
 
 BASE_DC = 10
 SAVING_THROW_ABILITY = "constitution"
-MULTIPLE_ROLES_PENALTY = -5
 
 # Load data
 journey_data = load_json(get_gvar("a6e3208c-b3c8-408b-b310-43e3daab5332"))
@@ -27,10 +26,6 @@ if args.get('dc'):
         title = "Error"
         desc = f"Invalid DC value: {args.last('dc')}"
         return common_utils.embed_msg(title=title, desc=desc, footer=footer)
-
-# Check for multiple roles penalty
-if 'multipleroles' in args:
-    bonuses.append(f"{MULTIPLE_ROLES_PENALTY}[Multiple Roles]")
 
 # Check for blessing die
 if 'blessingdie' in args:

--- a/collection/LOTR 5E/lotrfatigue.md
+++ b/collection/LOTR 5E/lotrfatigue.md
@@ -9,7 +9,6 @@ Performs a fatigue saving throw in the "Lord of the Rings" system. Calculates a 
   - `-dc <value>` - Sets a custom difficulty class (DC) for the saving throw. Defaults to 10.
   - `-b <value>` - Adds custom bonuses to the saving throw.
   - `blessingdie` - Adds a blessing die to the saving throw.
-  - `multipleroles` - Applies a -5 penalty for taking multiple roles during the journey.
   - `-mount <value>` - Adds a mount bonus to the saving throw.
   - `-event|e <event|abbr>` - Adds an event consequence modifier to the DC. Use either the event name or abbreviation.
   - `autumn|winter` - Applies disadvantage due to seasonal conditions.
@@ -19,8 +18,8 @@ Performs a fatigue saving throw in the "Lord of the Rings" system. Calculates a 
   `!lotrfatigue`
 - Add a blessing die and apply a mount bonus of 3:  
   `!lotrfatigue blessingdie -mount 3`
-- Apply a custom DC of 15 with multiple roles penalty:  
-  `!lotrfatigue -dc 15 multipleroles`
+- Apply a custom DC of 15:  
+  `!lotrfatigue -dc 15`
 - Add an event modifier using its abbreviation:  
   `!lotrfatigue -e tm`
 - Roll with disadvantage for autumn conditions:  
@@ -30,7 +29,7 @@ Performs a fatigue saving throw in the "Lord of the Rings" system. Calculates a 
 - The base DC for the saving throw is 10 unless overridden by the `-dc` argument or modified by events.
 - Advantage or disadvantage can be applied directly using `adv` or `dis`.
 - Events modify the DC dynamically. You can add multiple events using `-e <event|abbr>` or `-event <event|abbr>`.
-- Mount bonuses, blessing dice, and penalties for multiple roles are automatically factored into the roll if specified.
+- Mount bonuses and blessing dice are automatically factored into the roll if specified.
 - Designed for use with the "Lord of the Rings" Roleplaying system.
 
 ## Issues?

--- a/collection/LOTR 5E/lotrfatigue.md
+++ b/collection/LOTR 5E/lotrfatigue.md
@@ -11,7 +11,6 @@ Performs a fatigue saving throw in the "Lord of the Rings" system. Calculates a 
   - `blessingdie` - Adds a blessing die to the saving throw.
   - `-mount <value>` - Adds a mount bonus to the saving throw.
   - `-event|e <event|abbr>` - Adds an event consequence modifier to the DC. Use either the event name or abbreviation.
-  - `autumn|winter` - Applies disadvantage due to seasonal conditions.
 
 ## Examples
 - Perform a fatigue saving throw with the default DC:  
@@ -22,8 +21,6 @@ Performs a fatigue saving throw in the "Lord of the Rings" system. Calculates a 
   `!lotrfatigue -dc 15`
 - Add an event modifier using its abbreviation:  
   `!lotrfatigue -e tm`
-- Roll with disadvantage for autumn conditions:  
-  `!lotrfatigue autumn`
 
 ## Notes
 - The base DC for the saving throw is 10 unless overridden by the `-dc` argument or modified by events.


### PR DESCRIPTION
## Fixes
- Delete journey roles from `!lotrfatigue` command
#6 
- Delete seasons from `!lotrfatigue` command
#11
- Ensure all files end with a newline character (required by POSIX standard)