### PR TITLE
Fixes to `!lotrevent` command

### DIFF
--- a/collection/LOTR 5E/metadata/lotrjourney_metadata_a6e3208c-b3c8-408b-b310-43e3daab5332.gvar
+++ b/collection/LOTR 5E/metadata/lotrjourney_metadata_a6e3208c-b3c8-408b-b310-43e3daab5332.gvar
@@ -83,11 +83,6 @@
     }
   },
   "roles": {
-    "guide": {
-        "title": "Guide",
-        "skill": "travel",
-        "function": "In charge of all decisions concerning route, rest, and supplies."
-    },
     "hunter": {
         "title": "Hunter",
         "skill": "hunting",

--- a/collection/LOTR 5E/metadata/lotrjourney_metadata_a6e3208c-b3c8-408b-b310-43e3daab5332.gvar
+++ b/collection/LOTR 5E/metadata/lotrjourney_metadata_a6e3208c-b3c8-408b-b310-43e3daab5332.gvar
@@ -83,20 +83,17 @@
     }
   },
   "roles": {
-    "hunter": {
-        "title": "Hunter",
-        "skill": "hunting",
-        "function": "In charge of finding food in the wild."
+    "hunters": {
+        "title": "Hunters",
+        "skill": "hunting"
     },
-    "lookout": {
-        "title": "Look-out",
-        "skill": "perception",
-        "function": "In charge of keeping watch."
+    "lookouts": {
+        "title": "Look-outs",
+        "skill": "perception"
     },
-    "scout": {
-        "title": "Scout",
-        "skill": "explore",
-        "function": "In charge of setting up camp, opening new trails."
+    "scouts": {
+        "title": "Scouts",
+        "skill": "explore"
     }
   }
 }


### PR DESCRIPTION
## Fixes
- Delete invalid guide role from `!lotrevent` command #5
- Conform event target roles with rules nomenclature, and delete unused role function descriptions
- Add missing newlines