### PR TITLE
Fix Treasure Hunter class name matching in `!lotrshadow setup` command

### DIFF
--- a/collection/LOTR 5E/lotrshadow setup.alias
+++ b/collection/LOTR 5E/lotrshadow setup.alias
@@ -18,7 +18,7 @@ valid_callings = list(shadow_data["paths"].keys())
 calling = None
 
 for possible_calling in valid_callings:
-    class_name = possible_calling.replace(" ", "")
+    class_name = possible_calling
     if ch.levels.get(class_name, 0) > 0:
         calling = possible_calling
         break


### PR DESCRIPTION
## Fixes
- Delete unsafe string replacement: `.replace(" ", "")`
_This was the bug._